### PR TITLE
Add URL params for {,h3}hexagonlayer: elevationScale and bearing

### DIFF
--- a/cmp-h3hexagonlayer.html
+++ b/cmp-h3hexagonlayer.html
@@ -75,8 +75,10 @@ if (latlonParam) {
     latlon = latlonParam.split(',').map(Number);
 }
 let zoom = +urlParams.get('zoom') || 11;
-let pitch = urlParams.has('pitch') ? +urlParams.get('pitch') : 0; // allow 0
+let pitch = +urlParams.get('pitch') || 0;
+let bearing = +urlParams.get('bearing') || 0;
 const radiuskeyParam = urlParams.get('radiuskey');
+let elevationScale = +urlParams.get('elevationScale') || 0;
 let mapStyle = urlParams.get('mapStyle') || 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 const filterProp = urlParams.get('filterProp');
 const filterPropValue = urlParams.get('filterPropValue');
@@ -130,6 +132,7 @@ const map = new maplibregl.Map({
     center: [latlon[1], latlon[0]],
     zoom: zoom,
     pitch: pitch,
+    bearing: bearing,
     maxPitch: 85,
 });
 const overlay = new deck.MapboxOverlay({layers: []});
@@ -170,6 +173,7 @@ function loadData(json, idx) {
             center: [lng, lat],
             zoom: zoom,
             pitch: pitch,
+            bearing: bearing,
         });
     }
     const valuekeys = json.valuekeys || [];
@@ -261,7 +265,7 @@ function timeinterval(features) {
 
 function renderLayer() {
     const layers = jsons.map((json, idx) => {
-        return new deck.H3HexagonLayer({
+        const layercfg = {
             id: `H3HexagonLayer-${idx}`,
             data: json.features,
             getHexagon: d => d.hex_id,
@@ -272,7 +276,14 @@ function renderLayer() {
             updateTriggers: {
                 getFillColor: curTimes[idx],
             },
-        });
+        };
+        if (elevationScale > 0) {
+            layercfg.extruded = true;
+            layercfg.getElevation = d => Math.abs(getPointRadiusAtTime(d, curTimes[idx]));
+            layercfg.elevationScale = elevationScale;
+            layercfg.updateTriggers['getElevation'] = curTimes[idx];
+        }
+        return new deck.H3HexagonLayer(layercfg);
     });
     overlay.setProps({
         layers: layers,

--- a/dual-h3hexagonlayer.html
+++ b/dual-h3hexagonlayer.html
@@ -77,8 +77,10 @@ if (latlonParam) {
     latlon = latlonParam.split(',').map(Number);
 }
 let zoom = +urlParams.get('zoom') || 11;
-let pitch = urlParams.has('pitch') ? +urlParams.get('pitch') : 0; // allow 0
+let pitch = +urlParams.get('pitch') || 0;
+let bearing = +urlParams.get('bearing') || 0;
 const radiuskeyParam = urlParams.get('radiuskey');
+let elevationScale = +urlParams.get('elevationScale') || 0;
 let mapStyle = urlParams.get('mapStyle') || 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 const filterProp = urlParams.get('filterProp');
 const filterPropValue = urlParams.get('filterPropValue');
@@ -133,6 +135,7 @@ for (let i = 0; i < 2; i++) {
         center: [latlon[1], latlon[0]],
         zoom: zoom,
         pitch: pitch,
+        bearing: bearing,
         maxPitch: 85,
     }));
     overlays.push(new deck.MapboxOverlay({layers: []}));
@@ -175,6 +178,7 @@ function loadData(json, idx) {
             center: [lng, lat],
             zoom: zoom,
             pitch: pitch,
+            bearing: bearing,
         });
     }
     const valuekeys = json.valuekeys || [];
@@ -275,6 +279,12 @@ function renderLayer(json, time, idx) {
             getFillColor: time,
         },
     };
+    if (elevationScale > 0) {
+        layercfg.extruded = true;
+        layercfg.getElevation = d => Math.abs(getPointRadiusAtTime(d, time));
+        layercfg.elevationScale = elevationScale;
+        layercfg.updateTriggers['getElevation'] = time;
+    }
     overlays[idx].setProps({
         layers: new deck.H3HexagonLayer(layercfg),
     });

--- a/h3hexagonlayer.html
+++ b/h3hexagonlayer.html
@@ -181,8 +181,9 @@ function renderLayer(json) {
     };
     if (elevationScale > 0) {
         layercfg.extruded = true;
-        layercfg.getElevation = d => Math.abs(d[radiuskey]);
+        layercfg.getElevation = d => Math.abs(getPointRadiusAtTime(d, time));
         layercfg.elevationScale = elevationScale;
+        layercfg.updateTriggers['getElevation'] = time;
     }
     deckgl.setProps({
         layers: new deck.H3HexagonLayer(layercfg),

--- a/h3hexagonlayer.html
+++ b/h3hexagonlayer.html
@@ -41,10 +41,11 @@ if (latlonParam) {
     latlon = latlonParam.split(',').map(Number);
 }
 let zoom = +urlParams.get('zoom') || 11;
-let pitch = urlParams.has('pitch') ? +urlParams.get('pitch') : 0; // allow 0
+let pitch = +urlParams.get('pitch') || 0;
+let bearing = +urlParams.get('bearing') || 0;
 let interval = +urlParams.get('intervalMs') || 1000;
 const radiuskeyParam = urlParams.get('radiuskey');
-const serieskey = urlParams.get('serieskey');
+let elevationScale = +urlParams.get('elevationScale') || 0;
 let mapStyle = urlParams.get('mapStyle') || 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 const filterProp = urlParams.get('filterProp');
 const filterPropValue = urlParams.get('filterPropValue');
@@ -69,6 +70,7 @@ const deckgl = new deck.DeckGL({
         latitude: latlon[0],
         zoom: zoom,
         pitch: pitch,
+        bearing: bearing,
         maxPitch: 85,
     },
     mapOptions: {
@@ -101,12 +103,14 @@ function loadData(json) {
                 latitude: lat,
                 zoom: zoom,
                 pitch: pitch,
+                bearing: bearing,
                 maxPitch: 85,
             },
         });
     }
     const values = json.features.flatMap(x => x[radiuskey]);
     const colors = values.some(x => x < 0) ? COLORS_WITHNEG : COLORS;
+    // TODO: not use red in COLORS_WITHNEG for negative values
     colorScale = d3.scaleQuantile().range(colors).domain(values);
 
     const [timeMin, timeMax, tick] = timeinterval(json.features);
@@ -165,20 +169,23 @@ function timeinterval(data) {
 }
 
 function renderLayer(json) {
-    const layer = new deck.H3HexagonLayer({
+    const layercfg = {
         id: 'H3HexagonLayer',
         data: json.features,
         getHexagon: d => d.hex_id,
         extruded: false,
-        //getElevation: d => d[radiuskey],
-        //elevationScale: 20,
         getFillColor: d => getColor(d, time),
         updateTriggers: {
             getFillColor: time,
         },
-    });
+    };
+    if (elevationScale > 0) {
+        layercfg.extruded = true;
+        layercfg.getElevation = d => Math.abs(d[radiuskey]);
+        layercfg.elevationScale = elevationScale;
+    }
     deckgl.setProps({
-        layers: layer,
+        layers: new deck.H3HexagonLayer(layercfg),
     });
 }
 
@@ -186,7 +193,7 @@ function getColor(d, time) {
     const radius = getPointRadiusAtTime(d, time);
     const rgbstr = colorScale(radius);
     const rgb = rgbstr.slice(1).match(/.{2}/g).map(hex => parseInt(hex, 16));
-    return [...rgb, 200];
+    return [...rgb, 230];
 }
 
 function getPointRadiusAtTime(d, time) {

--- a/hexagonlayer.html
+++ b/hexagonlayer.html
@@ -39,6 +39,7 @@ if (latlonParam) {
 }
 let zoom = +urlParams.get('zoom') || 10;
 let pitch = urlParams.has('pitch') ? +urlParams.get('pitch') : 20; // allow 0
+let bearing = +urlParams.get('bearing') || 0;
 let interval = +urlParams.get('intervalMs') || 1000;
 let radius = +urlParams.get('radius') || 500;
 let elevationScale = +urlParams.get('elevationScale') || 20;
@@ -77,6 +78,7 @@ const deckgl = new deck.DeckGL({
         latitude: latlon[0],
         zoom: zoom,
         pitch: pitch,
+        bearing: bearing,
         maxPitch: 85,
     },
     mapOptions: {
@@ -99,6 +101,7 @@ function loadData(json) {
                 latitude: latlon[0],
                 zoom: zoom,
                 pitch: pitch,
+                bearing: bearing,
                 maxPitch: 85,
             },
         });


### PR DESCRIPTION
* [docomo-cycle](https://deton.github.io/HeatMapWithTime/h3hexagonlayer.html?latlon=35.5903,139.6630&zoom=9.9&jsonurl=https://deton.github.io/HeatMapWithTime/sampledata/1005-PT30M_difftimesum_diff_h3.json&radiuskey=rent&filterProp=systemId&filterPropValue=docomo-cycle&elevationScale=50&pitch=30)
* [hellocycling](https://deton.github.io/HeatMapWithTime/h3hexagonlayer.html?latlon=35.6454,139.7385&zoom=9.9&jsonurl=https://deton.github.io/HeatMapWithTime/sampledata/1005-PT30M_difftimesum_diff_h3.json&radiuskey=rent&filterProp=systemId&filterPropValue=hellocycling&elevationScale=50&pitch=30)

![h3-diff-docomo-extruded](https://github.com/user-attachments/assets/69aa6681-4323-41e4-847c-05510021af44)

## dual-h3hexagonlayer.html
* [docomo-cycle](https://deton.github.io/HeatMapWithTime/dual-h3hexagonlayer.html?latlon=35.5993,139.6724&zoom=10.4&jsonurl=https://deton.github.io/HeatMapWithTime/sampledata/15-PT30M-capacity_difftimesum_h3.json&jsonurl=https://deton.github.io/HeatMapWithTime/sampledata/1005-PT30M_difftimesum_h3.json&radiuskey=rent&filterProp=systemId&filterPropValue=docomo-cycle&elevationScale=20&pitch=30)

![dual-h3-docomo-extruded](https://github.com/user-attachments/assets/e6201ec9-093b-4660-8ee5-070978c91165)
