### PR TITLE
GeoJSONのPointを指定半径(メートル単位)の円で表示

### DIFF
--- a/MarkerStyleWithTime.html
+++ b/MarkerStyleWithTime.html
@@ -100,18 +100,7 @@ map.timeDimension = L.timeDimension({
     duration: 'PT30M',
 });
 
-const tdControl = new L.Control.TimeDimensionCustom({
-    autoPlay: true,
-    loopButton: true,
-    minSpeed: 1,
-    speedStep: 0.5,
-    playerOptions: {
-        loop: true,
-        startOver: true,
-    },
-});
-map.addControl(tdControl);
-
+let tdControl;
 let iconDLayer;
 
 function loadData(data, filename) {
@@ -184,6 +173,19 @@ function loadData(data, filename) {
         iconLayer.addTo(map);
         layerControl.addOverlay(iconLayer, filename);
         return;
+    }
+    if (!tdControl) { // add tdControl only if hasTimes
+        tdControl = new L.Control.TimeDimensionCustom({
+            autoPlay: true,
+            loopButton: true,
+            minSpeed: 1,
+            speedStep: 0.5,
+            playerOptions: {
+                loop: true,
+                startOver: true,
+            },
+        });
+        map.addControl(tdControl);
     }
     //if (iconDLayer) {
     //    layerControl.remove(iconDLayer);

--- a/MarkerStyleWithTime.html
+++ b/MarkerStyleWithTime.html
@@ -62,6 +62,8 @@ const baseLayers = {
 var map = L.map('map', {
     preferCanvas: true,
     layers: [baseLayers['maptiler-basic-ja']],
+    center: [35.7574, 139.7293],
+    zoom: 13,
 });
 const layerControl = L.control.layers(baseLayers, null).addTo(map);
 
@@ -166,12 +168,12 @@ function loadData(data, filename) {
         };
     }
     const iconLayer = L.geoJson(data, geojsonOptions);
-    if (!latlon) {
-        map.fitBounds(iconLayer.getBounds());
-    }
     if (!hasTimes) { // add geojson layer if no times. (instead of replacing)
         iconLayer.addTo(map);
         layerControl.addOverlay(iconLayer, filename);
+        if (!latlon) {
+            map.fitBounds(iconLayer.getBounds());
+        }
         return;
     }
     if (!tdControl) { // add tdControl only if hasTimes
@@ -199,6 +201,9 @@ function loadData(data, filename) {
     });
     iconDLayer.addTo(map);
     layerControl.addOverlay(iconDLayer, filename);
+    if (!latlon) {
+        map.fitBounds(iconLayer.getBounds());
+    }
 }
 
 // based on https://github.com/python-visualization/folium/blob/553a33981fa29a9d4ce6c426563749188906610f/folium/plugins/timestamped_geo_json.py#L102

--- a/MarkerStyleWithTime.html
+++ b/MarkerStyleWithTime.html
@@ -223,17 +223,24 @@ function pointToLayer(feature, latLng, radiuskey) {
         }
         if (iconstyle) {
             if (!radiuskey) {
-                return new L.circleMarker(latLng, iconstyle);
+                if (iconstyle.radiusUnit === 'meter') {
+                    return new L.Circle(latLng, iconstyle);
+                }
+                return new L.CircleMarker(latLng, iconstyle);
             }
             const idx = getTimeIdx(feature.properties.times);
             const defradius = iconstyle.radius || 2;
-            return new L.circleMarker(latLng, {
+            const opts = {
                 ...iconstyle,
                 radius: feature.properties[radiuskey].at(idx) + defradius,
                 //radius: Math.log2(1 + feature.properties[radiuskey].at(idx)) + defradius,
-            });
+            };
+            if (iconstyle.radiusUnit === 'meter') {
+                return new L.Circle(latLng, opts);
+            }
+            return new L.CircleMarker(latLng, opts);
         }
-        return new L.circleMarker(latLng);
+        return new L.CircleMarker(latLng);
     }
     return new L.Marker(latLng);
 }

--- a/geojsonlayer.html
+++ b/geojsonlayer.html
@@ -124,6 +124,8 @@ function loadData(json) {
         slider.style.display = "none";
         playButton.style.display = "none";
         pauseButton.style.display = "none";
+        renderLayer(json);
+        return;
     }
     slider.min = String(timeMin);
     slider.max = String(timeMax);
@@ -206,11 +208,11 @@ function renderLayer(json) {
 }
 
 function getColor(feature, isfill, time) {
-    let color = feature.properties.iconstyle && feature.properties.iconstyle.color;
+    let color = feature.properties.iconstyle?.color;
     if (!color) {
         return [255, 0, 0, isfill ? 153 : 255];
     }
-    const colorneg = feature.properties.iconstyle.colorneg;
+    const colorneg = feature.properties.iconstyle?.colorneg;
     if (radiuskey && colorneg) {
         const radius = getPointRadiusAtTime(feature, time);
         if (radius < 0) {
@@ -251,7 +253,23 @@ function getIconColor(feature, time) {
 
 function getPointRadiusAtTime(feature, time) {
     const idx = getTimeIdx(feature, time);
-    const radius = feature.properties[radiuskey].at(idx);
+    let radius;
+    if (idx < 0) {
+        if (radiuskey) {
+            radius = feature.properties[radiuskey];
+        } else {
+            radius = feature.properties.iconstyle?.radius;
+        }
+    } else {
+        if (radiuskey) {
+            radius = feature.properties[radiuskey].at(idx);
+        } else {
+            radius = feature.properties.iconstyle?.radius;
+        }
+    }
+    if (radius === undefined) {
+        radius = 2;
+    }
     if (filterParam === '>0') {
         return radius > 0 ? radius : 0;
     }


### PR DESCRIPTION
# GeoJSONのPointを指定半径(メートル単位)の円で表示
## 目的

* GeoJSONのPointを指定半径(例:500m)の円で表示したい。
* このためだけのツールを作るより、GeoJSONファイルを指定して表示するサイトにしたい。

### 調査

* https://geojson.io では、PointはMarkerで表示される。
  * (draw toolで円を作るとPolygonが生成される)
* https://kepler.gl では半径指定はpixel単位?
* LeafletのL.Circleを使えばメートル単位で半径指定可能。
* deck.glのGeoJsonLayerのpointRadiusUnitsはデフォルトでmeters。
* foliumのTimestampedGeoJsonでは、`{{"properties": {"icon": "circle","iconstyle":{"radius":10}}},"geometry":{"type":"Point",...}}`は、L.CircleMarkerで表示される。半径はpixel単位。

## 対処

* foliumのTimestampedGeoJsonをベースに、メートル単位での半径指定用プロパティ`"radiusUnit":"meter"`を追加: `{{"properties": {"icon": "circle","iconstyle":{"radius":500,"radiusUnit":"meter"}}},"geometry":{"type":"Point",...}}`
* https://deton.github.io/HeatMapWithTime/MarkerStyleWithTime.html に、`"radiusUnit": "meter"`の場合はL.Circleを使って円を表示する処理を追加。

### 他の案

* Pointを円相当のポリゴンに変換するツール。
  * 今回は表示したいだけだったので不採用。

## 表示例 (Tissot Indicatrix。半径800km)
https://deton.github.io/HeatMapWithTime/MarkerStyleWithTime.html?jsonurl=https://gist.githubusercontent.com/deton/0df0540d196ba881de20b14cfb12e153/raw/5f008580428ebfab954eaab78cb2615bd4d4f78b/tissotIndicatrix.geojson

<img width="1377" height="882" alt="Screenshot 2025-08-31 at 20-38-44 TimestampedGeoJson" src="https://github.com/user-attachments/assets/7dd3a186-c548-48ef-a052-f2483627edbe" />

https://deton.github.io/HeatMapWithTime/geojsonlayer.html?radiusScale=1&zoom=1&latlon=0,0&jsonurl=https://gist.githubusercontent.com/deton/0df0540d196ba881de20b14cfb12e153/raw/5f008580428ebfab954eaab78cb2615bd4d4f78b/tissotIndicatrix.geojson

<img width="1447" height="882" alt="Screenshot 2025-08-31 at 20-40-51 TimestampedGeoJson" src="https://github.com/user-attachments/assets/da295e7d-63f4-446c-95f9-02d96197419a" />
